### PR TITLE
Updated to SpongeAPI 4.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.hierynomus.license' version '0.11.0'
+    id 'net.minecrell.licenser' version '0.1.3'
 }
 
 allprojects {
@@ -70,16 +70,14 @@ allprojects {
         }
     }
 
-    apply plugin: 'com.github.hierynomus.license'
+    apply plugin: 'net.minecrell.licenser'
 
     license {
         header rootProject.file('LICENSE')
         include '**/*.java'
 
-        strictCheck true
-        mapping {
-            java = 'SLASHSTAR_STYLE'
-        }
+        newLine = false
+        style.java = 'BLOCK_COMMENT'
     }
 }
 
@@ -106,5 +104,5 @@ dependencies {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.10'
+    gradleVersion = '2.11'
 }

--- a/sponge/build.gradle
+++ b/sponge/build.gradle
@@ -9,5 +9,5 @@ repositories {
 }
 
 dependencies {
-    provided 'org.spongepowered:spongeapi:3.0.0'
+    provided 'org.spongepowered:spongeapi:4.0.1'
 }

--- a/sponge/src/main/java/net/minecrell/mcstats/SpongeStatsLite.java
+++ b/sponge/src/main/java/net/minecrell/mcstats/SpongeStatsLite.java
@@ -109,7 +109,7 @@ public final class SpongeStatsLite extends StatsLite {
 
     @Override
     protected String getPluginVersion() {
-        return this.plugin.getVersion();
+        return this.plugin.getVersion().isPresent() ? this.plugin.getVersion().get() : "unknown";
     }
 
     @Override


### PR DESCRIPTION
- Updated to gradle 2.11
- Used @minecrell 's licenser
- Updated to SpongeAPI 4.0.1
- Please bump version later

For some plugins that uses statslite, they need an update for statslite in order to work on SpongeAPI 4.x.x.
